### PR TITLE
Fix typo in URL link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Rew! I'm Kelvin, a shadewing who makes pixel art and programs games, mainly using C++ and Squirrel, though I have some knowledge of C#, Java, JavaScript, and Game Maker.
 
-I'm currently working on [Kyrodian Legends](https://gitub.com/kelvinshadewing/kyrodianlegends), an open source action platform game featuring much of my own graphics, as well as a variety of creative commons assets that have been modified to fit into the style of the game.
+I'm currently working on [Kyrodian Legends](https://github.com/kelvinshadewing/kyrodianlegends), an open source action platform game featuring much of my own graphics, as well as a variety of creative commons assets that have been modified to fit into the style of the game.
 
 KL is being written in my custom SDL-based game engine, [Brux](https://github.com/kelvinshadewing/brux-gdk), an engine designed to write games in the [Squirrel scripting language](https://squirrel-lang.org). So basically, I'm writing a game about a squirrel in Squirrel! Brux continues its rodent theme by using [Chipmunk](https://chipmunk-physics.net/) as a built-in advanced physics engine.
 


### PR DESCRIPTION
A drive-by typo fix (the link doesn't currently work). 

I landed on your GitHub profile from seeing SuperTux Advance on YouTube.